### PR TITLE
Fix [ShouldReturnMostQualifiedMediaTypeWhenDefaultHasQualifier] and [Sho...

### DIFF
--- a/Restfulie.Server/Negotiation/AcceptHeaderToMediaType.cs
+++ b/Restfulie.Server/Negotiation/AcceptHeaderToMediaType.cs
@@ -65,7 +65,7 @@ namespace Restfulie.Server.Negotiation
             {
                 var typeInfo = type.Split(';');
                 format = typeInfo[0].Trim();
-                qualifier = Convert.ToDouble(typeInfo[1].Split('=')[1]);
+                qualifier = Convert.ToDouble(typeInfo[1].Split('=')[1], new CultureInfo("en-US"));
             }
             else
             {


### PR DESCRIPTION
...uldReturnMostQualifiedMediaTypeWhenQualifierIsNotPresent] when culture is no en-US.

Example: when this project is used in a project with culture pt-Br, qualifier 0.9 is converted to 9.0
