### PR TITLE
Correcting hypermedia links

### DIFF
--- a/Restfulie.Server/Marshalling/UrlGenerators/AspNetMvcUrlGenerator.cs
+++ b/Restfulie.Server/Marshalling/UrlGenerators/AspNetMvcUrlGenerator.cs
@@ -17,9 +17,8 @@ namespace Restfulie.Server.Marshalling.UrlGenerators
         }
 
         private string FullApplicationPath(HttpRequestBase request)
-        {
-            var url = request.Url.AbsoluteUri.Replace(request.Url.AbsolutePath, string.Empty) + request.ApplicationPath;
-            return url.EndsWith("/") ? url.Substring(0, url.Length - 1) : url;
+        { 
+            return request.Url.Scheme + "://" + request.Url.Authority;
         }
     }
 }


### PR DESCRIPTION
...previous implementation was generating wrong paths when the application was deployed in a virtual directory that was not the root domain
